### PR TITLE
Adding shortcuts for tmux resizing

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -15,6 +15,13 @@ bind -n M-Right select-pane -R
 bind -n M-Up select-pane -U
 bind -n M-Down select-pane -D
 
+# Resize panes with alt+shift+arrow
+bind -r -n M-S-Left resize-pane -L 5
+bind -r -n M-S-Right resize-pane -R 5
+bind -r -n M-S-Up resize-pane -U 5
+bind -r -n M-S-Down resize-pane -D 5
+
+
 # Mouse mode (tmux 2.1 and above)
 set -g mouse on
 


### PR DESCRIPTION
I like these shortcuts, I got used to the built in ones in windows terminal. You do have to remove the existing default shortcuts in terminal or it will capture the input and not pass it to tmux.